### PR TITLE
add gnu reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage:
 Options:
 
   -h, --help               Output usage information
-  -r, --reporter <name>    Format of output: console (default), checkstyle, json
+  -r, --reporter <name>    Format of output: console (default), checkstyle, json, gnu
   -v, --version            Output version
 ```
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,7 +5,7 @@ var validateString = require('./validate.js').validateString;
 
 var command = cli.create('csstree-validate', '[fileOrDir]')
     .version(require('../package.json').version)
-    .option('-r, --reporter <name>', 'Format of output: console (default), checkstyle, json', function(name) {
+    .option('-r, --reporter <name>', 'Format of output: console (default), checkstyle, json, gnu', function(name) {
         if (!reporters.hasOwnProperty(name)) {
             throw new cli.Error('Wrong value for reporter: ' + name);
         }

--- a/lib/reporter/gnu.js
+++ b/lib/reporter/gnu.js
@@ -1,0 +1,34 @@
+// "FILENAME":LINE.COLUMN: error: MESSAGE
+// "FILENAME":START_LINE.COLUMN-END_LINE.COLUMN: error: MESSAGE
+module.exports = function(data) {
+    var output = [];
+
+    Object.keys(data).sort().forEach(function(filename) {
+        var errors = data[filename];
+
+        output.push(errors.map(function(entry) {
+            var error = entry.error || entry;
+            var line = entry.line || -1;
+            var column = entry.column || -1;
+            var position = line + '.' + column;
+            var message = entry.message || entry.error.rawMessage;
+            var value = error.css ? ': `' + error.css + '`' : '';
+            var allowed = error.syntax ? '; allowed: ' + error.syntax : '';
+            if (error.loc) {
+                position = error.loc.start.line + '.' +
+                    error.loc.start.column + '-' +
+                    error.loc.end.line + '.' +
+                    error.loc.end.column;
+            }
+            return '"' +
+                filename + '":' +
+                position + ': ' +
+                'error: ' +
+                message +
+                value +
+                allowed;
+        }).join('\n'));
+    });
+
+    return output.join('\n');
+};

--- a/lib/reporter/index.js
+++ b/lib/reporter/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     json: require('./json.js'),
     console: require('./console.js'),
-    checkstyle: require('./checkstyle.js')
+    checkstyle: require('./checkstyle.js'),
+    gnu: require('./gnu.js')
 };

--- a/test/fixture/reporter/gnu
+++ b/test/fixture/reporter/gnu
@@ -1,0 +1,5 @@
+"match.css":1.16-1.19: error: Invalid value for `color`: `123`; allowed: <color>
+"match.css":1.33-1.40: error: The rest part of value can't be matched to `border` syntax: `1px unknown red`; allowed: <br-width> || <br-style> || <color>
+"match.css":1.46: error: Unknown property `unknown`
+"parse.css":1.11: error: Colon is expected
+"parse.css":1.32-1.37: error: The rest part of value can't be matched to `color` syntax: `red green`; allowed: <color>


### PR DESCRIPTION
As documented at https://www.gnu.org/prep/standards/standards.html#Errors
and as used by, e.g., the Nu Html Checker (W3C HTML5 validator); see
https://github.com/validator/validator/wiki/Output-%C2%BB-GNU